### PR TITLE
procfile: remove the server run command

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,2 @@
 web: gunicorn dashboard.wsgi --log-file -
 web: python manage.py migrate && gunicorn dashboard.wsgi
-web: python manage.py runserver && gunicorn dashboard.wsgi


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove redundant server run command from the Procfile.